### PR TITLE
Refactor runner files to use only one NamesService instance

### DIFF
--- a/run/fancy_names.rb
+++ b/run/fancy_names.rb
@@ -1,19 +1,10 @@
 require "./lib/fancy_name_generator"
 require "./lib/names_service"
 
-location = "./data/names.txt"
+service = NamesService.new("./data/names.txt")
+names = service.names
 
-amount = ARGV[0]
-amount ||= 1
-
-amount.to_i.times do
-
-  service = NamesService.new(location)
-  names = service.names
-
-  generator = FancyNameGenerator.new(names)
-  fancy_name = generator.full_name
-
-  puts fancy_name
-
+(ARGV[0] || 1).to_i.times do
+  generator = FancyNameGenerator.new(names.sample(4))
+  puts generator.full_name
 end

--- a/run/names.rb
+++ b/run/names.rb
@@ -1,19 +1,10 @@
 require "./lib/name_generator"
 require "./lib/names_service"
 
-location = "./data/names.txt"
+service = NamesService.new("./data/names.txt")
+names = service.names
 
-amount = ARGV[0]
-amount ||= 1
-
-amount.to_i.times do
-
-  service = NamesService.new(location)
-  names = service.names
-
-  generator = NameGenerator.new(names)
-  name = generator.full_name
-
-  puts name
-
+(ARGV[0] || 1).to_i.times do
+  generator = NameGenerator.new(names.sample(4))
+  puts generator.full_name
 end

--- a/run/space_names.rb
+++ b/run/space_names.rb
@@ -1,19 +1,10 @@
 require "./lib/outer_space_name_generator"
 require "./lib/names_service"
 
-location = "./data/names.txt"
+service = NamesService.new("./data/names.txt")
+names = service.names
 
-amount = ARGV[0]
-amount ||= 1
-
-amount.to_i.times do
-
-  service = NamesService.new(location)
-  names = service.names
-
-  generator = OuterSpaceNameGenerator.new(names)
-  space_name = generator.full_name
-
-  puts space_name
-
+(ARGV[0] || 1).to_i.times do
+  generator = OuterSpaceNameGenerator.new(names.sample(4))
+  puts generator.full_name
 end


### PR DESCRIPTION
The NamesService only needs to be instantiated one time. I moved it out of the `.times do` loop because it was being instantiated multiple times.